### PR TITLE
Potential fix for code scanning alert no. 24: Useless regular-expression character escape

### DIFF
--- a/src/scan/react/parsers.ts
+++ b/src/scan/react/parsers.ts
@@ -345,7 +345,7 @@ export function parseRouterProviders(code: string, file: string, routes: Map<str
                             if (routesVarMatch) {
                                 const routesVar = routesVarMatch[1];
                                 console.log(`  Looking for routes variable: ${routesVar}`);
-                                const routeDefRegex = new RegExp(`(?:const|let|var)\s+${routesVar}\s*=\s*\[(([s\S]*?)\]`);
+                                const routeDefRegex = new RegExp(`(?:const|let|var)\\s+${routesVar}\\s*=\\s*\\[([\\s\\S]*?)\\]`);
                                 const routeDef = code.match(routeDefRegex);
                                 if (routeDef?.[1]) {
                                     console.log(`  Found routes definition in same file`);


### PR DESCRIPTION
Potential fix for [https://github.com/mikopos/create-ai-e2e/security/code-scanning/24](https://github.com/mikopos/create-ai-e2e/security/code-scanning/24)

To fix the issue, the regular expression string should be updated to correctly escape the backslash so that `\s` is interpreted as a whitespace character in the resulting regular expression. In JavaScript string literals, this requires doubling the backslash (`\\s`). This ensures that the constructed regular expression behaves as intended.

The specific change is to update the string in the `new RegExp` constructor on line 348 to use `\\s` instead of `\s`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
