### PR TITLE
Potential fix for code scanning alert no. 11: disallow unnecessary `catch` clauses

### DIFF
--- a/examples/sample-react-app/tests/home.spec.ts
+++ b/examples/sample-react-app/tests/home.spec.ts
@@ -1,13 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 test("/ renders", async ({ page }) => {
-  try {
-    await page.goto("/");
-    // Wait for the page to be fully loaded
-    await page.waitForLoadState("networkidle");
-    // Wait for the body to be visible
-    await expect(page.locator("body")).toBeVisible({ timeout: 10000 });
-  } catch (error) {
-    throw error;
-  }
+  await page.goto("/");
+  // Wait for the page to be fully loaded
+  await page.waitForLoadState("networkidle");
+  // Wait for the body to be visible
+  await expect(page.locator("body")).toBeVisible({ timeout: 10000 });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/mikopos/create-ai-e2e/security/code-scanning/11](https://github.com/mikopos/create-ai-e2e/security/code-scanning/11)

To fix the problem, we should remove the unnecessary `try/catch` block entirely. The `await` calls and assertions within the `test` function will naturally throw errors if something goes wrong, and these errors will propagate without the need for explicit rethrowing. This will simplify the code while maintaining its functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
