### PR TITLE
Potential fix for code scanning alert no. 10: disallow unnecessary `catch` clauses

### DIFF
--- a/examples/sample-react-app/tests/about.spec.ts
+++ b/examples/sample-react-app/tests/about.spec.ts
@@ -1,13 +1,9 @@
 import { test, expect } from "@playwright/test";
 
 test("/about renders", async ({ page }) => {
-  try {
-    await page.goto("/about");
-    // Wait for the page to be fully loaded
-    await page.waitForLoadState("networkidle");
-    // Wait for the body to be visible
-    await expect(page.locator("body")).toBeVisible({ timeout: 10000 });
-  } catch (error) {
-    throw error;
-  }
+  await page.goto("/about");
+  // Wait for the page to be fully loaded
+  await page.waitForLoadState("networkidle");
+  // Wait for the body to be visible
+  await expect(page.locator("body")).toBeVisible({ timeout: 10000 });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/mikopos/create-ai-e2e/security/code-scanning/10](https://github.com/mikopos/create-ai-e2e/security/code-scanning/10)

To fix the problem, we should remove the unnecessary `try/catch` block entirely. The `await` calls and assertions will naturally throw errors if something goes wrong, and these errors will propagate without the need for explicit rethrowing. This will simplify the code and adhere to the ESLint rule.

The changes will involve:
1. Removing the `try` block and its corresponding `catch` block.
2. Keeping the code inside the `try` block intact, as it does not need modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
