### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mikopos/create-ai-e2e/security/code-scanning/2](https://github.com/mikopos/create-ai-e2e/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are needed:
- `contents: read` to allow the workflow to check out the repository.
- `actions: read` to allow the workflow to use other actions.
- `write` permissions for `contents` are not required since the workflow does not modify repository contents.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
