### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mikopos/create-ai-e2e/security/code-scanning/1](https://github.com/mikopos/create-ai-e2e/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to restrict the permissions of the `GITHUB_TOKEN`. Since this workflow involves publishing to npm, it requires `contents: read` to access the repository contents and `packages: write` to publish the package. These permissions are the minimum required for the workflow to function correctly.

The `permissions` block will be added at the root of the workflow file, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
